### PR TITLE
Basic auth

### DIFF
--- a/api/Cargo.lock
+++ b/api/Cargo.lock
@@ -13,6 +13,7 @@ name = "api"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "base64",
  "bytes",
  "http",
  "rand",
@@ -32,6 +33,12 @@ dependencies = [
  "quote",
  "syn 2.0.8",
 ]
+
+[[package]]
+name = "base64"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4a4ddaa51a5bc52a6948f74c06d20aaaddb71924eab79b8c97a8c556e942d6a"
 
 [[package]]
 name = "bitflags"

--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -11,6 +11,7 @@ crate-type = [ "cdylib" ]
 [dependencies]
 # Useful crate to handle errors.
 anyhow = "1"
+base64 = "0.21.0"
 # Crate to simplify working with bytes.
 bytes = "1"
 # General-purpose crate with common HTTP types.


### PR DESCRIPTION
Adding basic auth to the API in the same way that Radu did in radu-matei/spin-kv-explorer. Important to note that if no credentials are found, they will be randomly generated and logged to standard output.

**Local Development**
During local development you will need to use the randomly generated values because there is no way to add to key-value during `spin up` like you can with `spin deploy`

**Deployment**
You can set credentials When you deploy your app like:

```
spin deploy --key-value '<username>:<password>'
```

Happy to adjust this if you'd like to make any changes.