### PR TITLE
Update Cargo Target to wasm32-wasip1 for Rust 1.84.0+ Compatibility

### DIFF
--- a/spin.toml
+++ b/spin.toml
@@ -7,12 +7,12 @@ version = "0.1.0"
 
 [[component]]
 id = "api"
-source = "api/target/wasm32-wasi/release/api.wasm"
+source = "api/target/wasm32-wasip1/release/api.wasm"
 key_value_stores = ["default"]
 [component.trigger]
 route = "/api/..."
 [component.build]
-command = "cargo build --target wasm32-wasi --release"
+command = "cargo build --target wasm32-wasip1 --release"
 workdir = "api"
 watch = [ "Cargo.toml", "src/lib.rs" ]
 
@@ -25,12 +25,12 @@ route = "/admin/..."
 
 [[component]]
 id = "redirect"
-source = "redirect/target/wasm32-wasi/release/redirect.wasm"
+source = "redirect/target/wasm32-wasip1/release/redirect.wasm"
 key_value_stores = ["default"]
 [component.trigger]
 route = "/..."
 [component.build]
-command = "cargo build --target wasm32-wasi --release"
+command = "cargo build --target wasm32-wasip1 --release"
 workdir = "redirect"
 watch = [ "Cargo.toml", "src/lib.rs" ]
 


### PR DESCRIPTION
This update modifies the `spin.toml` to replace the `wasm32-wasi` target with `wasm32-wasip1`, in accordance with the changes introduced in [Rust 1.84.0](https://github.com/rust-lang/rust/releases/tag/1.84.0#user-content-1.84.0-Compatibility-Notes).

## Changes:
- Updated the Cargo target and source directory from `wasm32-wasi` to `wasm32-wasip1`.
- This version has been tested and confirmed to work on both M1 MacBook Pro and Ferymon Cloud.

## Notes:
All related components that are referenced from this repository have already been updated accordingly:
- https://github.com/spinframework/spin-fileserver/blob/main/spin.toml
- https://github.com/mikkelhegn/spin-qr-generator/blob/main/spin.toml
